### PR TITLE
Add sanity check for blastn_vdb

### DIFF
--- a/blast/test.sh
+++ b/blast/test.sh
@@ -19,6 +19,7 @@ trap " /bin/rm -fr $TMP " INT QUIT EXIT HUP KILL ALRM
 time docker run --rm ${IMG} /bin/bash -c "printenv BLASTDB"
 
 time docker run --rm ${IMG} blastn -version
+time docker run --rm ${IMG} blastn_vdb -version-full
 time docker run --rm ${IMG} installconfirm
 time docker run --rm -v $TMP:/blast/blastdb:rw -w /blast/blastdb ${IMG} efetch -db nucleotide -id u00001 -format fasta | tee $TMP/u00001.fna
 time docker run --rm -v $TMP:/blast/blastdb:rw -w /blast/blastdb ${IMG} makeblastdb -in u00001.fna -dbtype nucl -out test-blastdb -title TEST


### PR DESCRIPTION
This is to perform a sanity check on the blastn_vdb binary, to ensure it built correctly.