### PR TITLE
Blast 2.14.0 updates for ease of maintenance and transparency

### DIFF
--- a/blast/2.14.0/Dockerfile
+++ b/blast/2.14.0/Dockerfile
@@ -33,7 +33,7 @@ RUN curl -s ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/${version}/ncbi-
  cd ncbi-blast-${version}+-src/c++ && \
  ./configure --with-mt --with-strip --with-optimization --with-dll --with-experimental=Int8GI --with-flat-makefile --with-openmp --with-vdb=${VDB} --without-gnutls --without-gcrypt --without-zstd --without-lzo --prefix=/blast && \
  cd ReleaseMT/build && \
- make -j ${num_procs} -f Makefile.flat blastdb_aliastool.exe blastdbcheck.exe blastdbcmd.exe blast_formatter.exe blastn.exe blastp.exe blastx.exe convert2blastmask.exe deltablast.exe dustmasker.exe makeblastdb.exe makembindex.exe makeprofiledb.exe psiblast.exe rpsblast.exe rpstblastn.exe segmasker.exe tblastn.exe tblastx.exe windowmasker.exe blastn_vdb.exe tblastn_vdb.exe blast_formatter_vdb.exe blast_vdb_cmd.exe
+ make -j ${num_procs} -f Makefile.flat blastdb_aliastool.exe blastdbcheck.exe blastdbcmd.exe blast_formatter.exe blastn.exe blastp.exe blastx.exe convert2blastmask.exe deltablast.exe dustmasker.exe makeblastdb.exe makembindex.exe makeprofiledb.exe psiblast.exe rpsblast.exe rpstblastn.exe segmasker.exe tblastn.exe tblastx.exe windowmasker.exe blastn_vdb.exe tblastn_vdb.exe blast_formatter_vdb.exe blast_vdb_cmd.exe blastdb_path.exe
 
 FROM google/cloud-sdk:slim as gsutil
 ARG version
@@ -57,17 +57,22 @@ ENV BLASTDB /blast/blastdb:/blast/blastdb_custom
 ENV BLAST_DOCKER true
 ENV PATH="/root/edirect:/blast/bin:${PATH}"
 
-RUN curl -s ftp://ftp.ncbi.nlm.nih.gov/blast/temp/${version}/blastdb_path -o /blast/bin/blastdb_path && chmod +x /blast/bin/blastdb_path && \
-    cp  /blast/bin/blastp /blast/bin/blastp.REAL && \
-    curl -s ftp://ftp.ncbi.nlm.nih.gov/blast/temp/${version}/blastp.sh -o /blast/bin/blastp  && chmod +x /blast/bin/blastp && \
+RUN cp  /blast/bin/blastp /blast/bin/blastp.REAL && \
     cp  /blast/bin/blastn /blast/bin/blastn.REAL && \
-    curl -s ftp://ftp.ncbi.nlm.nih.gov/blast/temp/${version}/blastn.sh -o /blast/bin/blastn  && chmod +x /blast/bin/blastn && \
     cp  /blast/bin/blastx /blast/bin/blastx.REAL && \
-    curl -s ftp://ftp.ncbi.nlm.nih.gov/blast/temp/${version}/blastx.sh -o /blast/bin/blastx  && chmod +x /blast/bin/blastx && \
     cp  /blast/bin/tblastn /blast/bin/tblastn.REAL && \
-    curl -s ftp://ftp.ncbi.nlm.nih.gov/blast/temp/${version}/tblastn.sh -o /blast/bin/tblastn  && chmod +x /blast/bin/tblastn && \
-    cp  /blast/bin/tblastx /blast/bin/tblastx.REAL && \
-    curl -s ftp://ftp.ncbi.nlm.nih.gov/blast/temp/${version}/tblastx.sh -o /blast/bin/tblastx  && chmod +x /blast/bin/tblastx
+    cp  /blast/bin/tblastx /blast/bin/tblastx.REAL
+
+COPY blastn.sh /blast/bin/blastn
+COPY blastp.sh /blast/bin/blastp
+COPY blastx.sh /blast/bin/blastx
+COPY tblastn.sh /blast/bin/tblastn
+COPY tblastx.sh /blast/bin/tblastx
+
+RUN chmod +x /blast/bin/blastn && chmod +x /blast/bin/blastp && \
+    chmod +x /blast/bin/blastx && chmod +x /blast/bin/tblastn && \
+    chmod +x /blast/bin/tblastx
+
 
 WORKDIR /blast
 

--- a/blast/2.14.0/blastn.sh
+++ b/blast/2.14.0/blastn.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+dbnametopass=0
+for i in $*; do	
+    #echo item: $i
+	if [ $i = "-db" ]; then		
+		dbnametopass=1
+		#echo dbnametopass: $dbnametopass	
+	elif [ $dbnametopass = 1 ]; then
+		dbname=$i
+		#echo database name: $dbname
+		break
+	else		
+		continue		
+	fi	
+ done 
+ #echo database name: $dbname 
+ if [ -n "$dbname" ]; then
+ 	filelist=$(blastdb_path -db $dbname -dbtype nucl -getvolumespath 2>/dev/null)
+	if [ $? = 0 ]; then	
+		#echo $filelist	
+		parallel vmtouch -tqm 5G ::: $filelist &	
+	fi	
+fi
+blastn.REAL "$@"
+
+
+
+

--- a/blast/2.14.0/blastp.sh
+++ b/blast/2.14.0/blastp.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+dbnametopass=0
+for i in $*; do	
+    #echo item: $i
+	if [ $i = "-db" ]; then		
+		dbnametopass=1
+		#echo dbnametopass: $dbnametopass	
+	elif [ $dbnametopass = 1 ]; then
+		dbname=$i
+		#echo database name: $dbname
+		break
+	else		
+		continue		
+	fi	
+ done 
+#echo database name: $dbname
+if [ -n "$dbname" ]; then
+	filelist=$(blastdb_path -db $dbname -dbtype prot -getvolumespath 2>/dev/null)
+	if [ $? = 0 ]; then	
+		#echo $filelist		
+		parallel vmtouch -tqm 5G ::: $filelist &		
+	fi	
+fi	
+blastp.REAL "$@"
+

--- a/blast/2.14.0/blastx.sh
+++ b/blast/2.14.0/blastx.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+dbnametopass=0
+for i in $*; do	
+    #echo item: $i
+	if [ $i = "-db" ]; then		
+		dbnametopass=1
+		#echo dbnametopass: $dbnametopass	
+	elif [ $dbnametopass = 1 ]; then
+		dbname=$i
+		#echo database name: $dbname
+		break
+	else		
+		continue		
+	fi	
+ done 
+#echo database name: $dbname
+if [ -n "$dbname" ]; then
+	filelist=$(blastdb_path -db $dbname -dbtype prot -getvolumespath 2>/dev/null)
+	if [ $? = 0 ]; then	
+		#echo $filelist
+		parallel vmtouch -tqm 5G ::: $filelist &		
+	fi	
+fi	
+blastx.REAL "$@"
+
+
+
+

--- a/blast/2.14.0/build-image.sh
+++ b/blast/2.14.0/build-image.sh
@@ -2,7 +2,7 @@
 
 DOCKERHUB_USERNAME=${1:-"ncbi"}
 IMAGE=blast
-VERSION=2.14.0
+VERSION=$(cat VERSION)
 # Check the latest ncbi-vdb release version in https://github.com/ncbi/ncbi-vdb/tags
 # To see which VDB version is currently used by C++ Toolkit do:
 #  grep local_vdb_base src/build-system/config.site.ncbi

--- a/blast/2.14.0/tblastn.sh
+++ b/blast/2.14.0/tblastn.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+dbnametopass=0
+for i in $*; do	
+    #echo item: $i
+	if [ $i = "-db" ]; then		
+		dbnametopass=1
+		#echo dbnametopass: $dbnametopass	
+	elif [ $dbnametopass = 1 ]; then
+		dbname=$i
+		#echo database name: $dbname
+		break
+	else		
+		continue		
+	fi	
+ done 
+ #echo database name: $dbname 
+if [ -n "$dbname" ]; then
+	filelist=$(blastdb_path -db $dbname -dbtype nucl -getvolumespath)
+	if [ $? = 0 ]; then	
+		#echo $filelist
+		parallel vmtouch -tqm 5G ::: $filelist &	
+	fi
+fi
+tblastn.REAL "$@"
+
+
+
+

--- a/blast/2.14.0/tblastx.sh
+++ b/blast/2.14.0/tblastx.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+dbnametopass=0
+for i in $*; do	
+    #echo item: $i
+	if [ $i = "-db" ]; then		
+		dbnametopass=1
+		#echo dbnametopass: $dbnametopass	
+	elif [ $dbnametopass = 1 ]; then
+		dbname=$i
+		#echo database name: $dbname
+		break
+	else		
+		continue		
+	fi	
+ done 
+ #echo database name: $dbname
+if [ -n "$dbname" ]; then 
+	filelist=$(blastdb_path -db $dbname -dbtype nucl -getvolumespath 2>/dev/null)
+	if [ $? = 0 ]; then	
+		#echo $filelist
+		parallel vmtouch -tqm 5G ::: $filelist &		
+	fi	
+fi
+tblastx.REAL "$@"
+
+
+
+


### PR DESCRIPTION
* Build `blastdb_path` from sources
* Include binary wrappers (`blastn.sh`, `blastp.sh`), etc in the repository

I noticed this later and wanted to do the update before we forget till the next release. I do not think there is any reason to copy `blastdb_path` from the ftp site if we can build it from sources along with other binaries. Including binary wrappers in the repository will make docker images more transparent, safer and it will be one less manual step when creating images for new releases. It will also allow for changes in the wrappers. Currently a change may break a build of an older image.