### PR TITLE
Don't rename aarch64 architecture JIRA SB-3832

### DIFF
--- a/blast-static/Dockerfile
+++ b/blast-static/Dockerfile
@@ -8,7 +8,7 @@ RUN mkdir -p /blast/blastdb /blast/blastdb_custom
 WORKDIR /blast
 
 RUN if [ $(uname -m) = x86_64 ] ; then arch=x64; \
-    elif [ $(uname -m) = aarch64 ] ; then arch=x64-arm; \
+    elif [ $(uname -m) = aarch64 ] ; then arch=aarch64; \
     else echo "Architecture $(uname -m) is not supported" >&2; exit 1; \
     fi &&  wget ftp://ftp.ncbi.nlm.nih.gov/blast/executables/LATEST/ncbi-blast-${version}+-${arch}-linux.tar.gz && tar xzf ncbi-blast-${version}+-${arch}-linux.tar.gz --strip-components=1 && rm ncbi-blast-${version}+-${arch}-linux.tar.gz
 


### PR DESCRIPTION
Leave returned by uname -m aarch64 as is to conform name of a static binary archive for ARM platform on FTP site