### PR TITLE
Add ca-certificates to magicblast image

### DIFF
--- a/magicblast/Dockerfile
+++ b/magicblast/Dockerfile
@@ -39,7 +39,8 @@ COPY VERSION .
 USER root
 WORKDIR /root/
 
-RUN apt-get -y -m update && apt-get install -y libxml2-dev libgomp1 && rm -rf /var/lib/apt/lists/*
+RUN apt-get -y -m update && apt-get install -y libxml2-dev libgomp1 ca-certificates && \
+   rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /blast/bin /blast/lib
 


### PR DESCRIPTION
* Fix suggested in Issue #43
* Add `ca-certificates` so that certificates from the host do not have to be attached to the container. 