### PR TITLE
Install the latest version (v1.22.0 released in Oct 2023) of IgBLAST

### DIFF
--- a/igblast/Dockerfile
+++ b/igblast/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:18.04
-ARG version=1.21.0
+ARG version=1.22.0
 LABEL Description="NCBI IgBLAST" Vendor="NCBI/NLM/NIH" Version=${version} Maintainer=jianye@ncbi.nlm.nih.gov
 
 USER root


### PR DESCRIPTION
https://ncbi.github.io/igblast/rel/Release-notes.html#oct-18-2023