### PR TITLE
blast-static 2.15.0 updates

### DIFF
--- a/blast-static/Dockerfile
+++ b/blast-static/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04
 ARG version
 
 USER root
-RUN apt-get -y -m update && apt-get install -y wget curl libidn-dev libnet-perl liblist-moreutils-perl perl-doc libgomp1 libxml2
+RUN apt-get -y -m update && apt-get install -y wget curl libidn-dev libnet-perl liblist-moreutils-perl perl-doc libgomp1 libxml2 libsqlite3-dev
 
 RUN mkdir -p /blast/blastdb /blast/blastdb_custom
 WORKDIR /blast

--- a/blast-static/build-image.sh
+++ b/blast-static/build-image.sh
@@ -11,6 +11,6 @@ case $(uname -m) in
 esac
 
 
-docker build --progress=plain --build-arg version="${VERSION}" -t "$DOCKERHUB_USERNAME"/$IMAGE:"$VERSION" --pull --no-cache . 2>&1 | tee build.log
+docker build --build-arg version="${VERSION}" -t "$DOCKERHUB_USERNAME"/$IMAGE:"$VERSION" --pull --no-cache . 2>&1 | tee build.log
 docker tag "$DOCKERHUB_USERNAME"/$IMAGE:"$VERSION" "$DOCKERHUB_USERNAME"/$IMAGE:latest
 docker tag "$DOCKERHUB_USERNAME"/$IMAGE:"$VERSION" "$DOCKERHUB_USERNAME"/$IMAGE:"${VERSION}"-${ARCH}


### PR DESCRIPTION
* Install `libsqlite3-dev`
* Removed deprecated docker option