### PR TITLE
blast-static 2.16.0

### DIFF
--- a/blast-static/Dockerfile
+++ b/blast-static/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /blast
 RUN if [ $(uname -m) = x86_64 ] ; then arch=x64; \
     elif [ $(uname -m) = aarch64 ] ; then arch=aarch64; \
     else echo "Architecture $(uname -m) is not supported" >&2; exit 1; \
-    fi &&  wget ftp://ftp.ncbi.nlm.nih.gov/blast/executables/LATEST/ncbi-blast-${version}+-${arch}-linux.tar.gz && tar xzf ncbi-blast-${version}+-${arch}-linux.tar.gz --strip-components=1 && rm ncbi-blast-${version}+-${arch}-linux.tar.gz
+    fi &&  wget ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/${version}/ncbi-blast-${version}+-${arch}-linux.tar.gz && tar xzf ncbi-blast-${version}+-${arch}-linux.tar.gz --strip-components=1 && rm ncbi-blast-${version}+-${arch}-linux.tar.gz
 
 
 # Needed for 2.13.0 Linux amd64 release


### PR DESCRIPTION
* Use a better URL to download BLAST+ release binaries